### PR TITLE
OXID-438: added the loadOrderBasketTotal method to the ShopgateBasket…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
-## 2.9.73
 ### Changed
 - Added method to directly set Oxid order total to be equal to Shopgate order total
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## 2.9.73
+### Changed
+- Added method to directly set Oxid order total to be equal to Shopgate order total
+
 ## 2.9.72
 ### Changed
 - migrated Shopgate integration for Oxid to GitHub

--- a/src/modules/shopgate/helpers/basket.php
+++ b/src/modules/shopgate/helpers/basket.php
@@ -102,6 +102,8 @@ class ShopgateBasketHelper extends ShopgateObject
             $this->loadOrderBasketPayment($oxBasket, $shopgateOrder);
         }
 
+        $this->loadOrderBasketTotal($oxBasket, $shopgateOrder);
+
         // As soon as the last calculateBasket() call happened we need to deactivate the deliverySet
         $this->shippingHelper->deactivateDeliverySet();
 
@@ -201,6 +203,19 @@ class ShopgateBasketHelper extends ShopgateObject
             $oxPrice->setPrice($paymentCost);
             $oxBasket->setCost('oxpayment', $oxPrice);
         }
+    }
+
+    /**
+     * @param shopgate_oxbasket $oxBasket
+     * @param ShopgateCartBase  $shopgateOrder
+     */
+    protected function loadOrderBasketTotal(shopgate_oxbasket &$oxBasket, ShopgateCartBase $shopgateOrder) {
+        $oxPrice = oxNew('oxPrice');
+        $oxPrice->setBruttoPriceMode();
+        $fDelVATPercent = $oxBasket->getProductsPrice()->getMostUsedVatPercent();
+        $oxPrice->setVat($fDelVATPercent);
+        $oxPrice->setPrice($shopgateOrder->getAmountComplete());
+        $oxBasket->setPrice($oxPrice);
     }
 
     /**

--- a/src/modules/shopgate/helpers/basket.php
+++ b/src/modules/shopgate/helpers/basket.php
@@ -206,17 +206,24 @@ class ShopgateBasketHelper extends ShopgateObject
     }
 
     /**
-     * @param shopgate_oxbasket $oxBasket
-     * @param ShopgateCartBase  $shopgateOrder
+     * @param shopgate_oxbasket $oxidBasket
+     * @param ShopgateCartBase  $shopgateCart
+     *
+     * @post if $oxidBasket supports the setPrice method price will be overwritten
      */
-    protected function loadOrderBasketTotal(shopgate_oxbasket &$oxBasket, ShopgateCartBase $shopgateOrder)
+    protected function loadOrderBasketTotal(shopgate_oxbasket $oxidBasket, ShopgateCartBase $shopgateCart)
     {
+        if (!method_exists($oxidBasket,"setPrice")) {
+
+            return;
+        }
+
+        /** @var oxPrice $oxPrice */
         $oxPrice = oxNew('oxPrice');
         $oxPrice->setBruttoPriceMode();
-        $fDelVATPercent = $oxBasket->getProductsPrice()->getMostUsedVatPercent();
-        $oxPrice->setVat($fDelVATPercent);
-        $oxPrice->setPrice($shopgateOrder->getAmountComplete());
-        $oxBasket->setPrice($oxPrice);
+        $oxPrice->setVat($oxidBasket->getProductsPrice()->getMostUsedVatPercent());
+        $oxPrice->setPrice($shopgateCart->getAmountComplete());
+        $oxidBasket->setPrice($oxPrice);
     }
 
     /**

--- a/src/modules/shopgate/helpers/basket.php
+++ b/src/modules/shopgate/helpers/basket.php
@@ -209,7 +209,8 @@ class ShopgateBasketHelper extends ShopgateObject
      * @param shopgate_oxbasket $oxBasket
      * @param ShopgateCartBase  $shopgateOrder
      */
-    protected function loadOrderBasketTotal(shopgate_oxbasket &$oxBasket, ShopgateCartBase $shopgateOrder) {
+    protected function loadOrderBasketTotal(shopgate_oxbasket &$oxBasket, ShopgateCartBase $shopgateOrder)
+    {
         $oxPrice = oxNew('oxPrice');
         $oxPrice->setBruttoPriceMode();
         $fDelVATPercent = $oxBasket->getProductsPrice()->getMostUsedVatPercent();

--- a/src/modules/shopgate/helpers/basket.php
+++ b/src/modules/shopgate/helpers/basket.php
@@ -214,7 +214,6 @@ class ShopgateBasketHelper extends ShopgateObject
     protected function loadOrderBasketTotal(shopgate_oxbasket $oxidBasket, ShopgateCartBase $shopgateCart)
     {
         if (method_exists($oxidBasket,"setPrice")) {
-
             /** @var oxPrice $oxPrice */
             $oxPrice = oxNew('oxPrice');
             $oxPrice->setBruttoPriceMode();

--- a/src/modules/shopgate/helpers/basket.php
+++ b/src/modules/shopgate/helpers/basket.php
@@ -213,17 +213,17 @@ class ShopgateBasketHelper extends ShopgateObject
      */
     protected function loadOrderBasketTotal(shopgate_oxbasket $oxidBasket, ShopgateCartBase $shopgateCart)
     {
-        if (!method_exists($oxidBasket,"setPrice")) {
+        if (method_exists($oxidBasket,"setPrice")) {
 
-            return;
+            /** @var oxPrice $oxPrice */
+            $oxPrice = oxNew('oxPrice');
+            $oxPrice->setBruttoPriceMode();
+            $oxPrice->setVat(
+                $oxidBasket->getProductsPrice()->getMostUsedVatPercent()
+            );
+            $oxPrice->setPrice($shopgateCart->getAmountComplete());
+            $oxidBasket->setPrice($oxPrice);
         }
-
-        /** @var oxPrice $oxPrice */
-        $oxPrice = oxNew('oxPrice');
-        $oxPrice->setBruttoPriceMode();
-        $oxPrice->setVat($oxidBasket->getProductsPrice()->getMostUsedVatPercent());
-        $oxPrice->setPrice($shopgateCart->getAmountComplete());
-        $oxidBasket->setPrice($oxPrice);
     }
 
     /**


### PR DESCRIPTION
Added the loadOrderBasketTotal method to the class ShopgateBasketHelper so that the oxBasket total could be set to the shopgate order total. The native calculateBasket can not trusted to see the added cost accurately and consistently. Like the loadOrderBasketShipping and loadOrderBasketPayment methods this method will ensure the total is set to the actual amount the shopper paid.