### PR TITLE
Sg 304 paypal order not imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- failing PayPalPlus order import
+
 ## [2.10.1] - 2024-06-14
 ### Fixed
 - using the `oxcmp_utils` component in the product description would lead the product export crashing

--- a/src/modules/shopgate/helpers/payment/paypalplus.php
+++ b/src/modules/shopgate/helpers/payment/paypalplus.php
@@ -35,8 +35,11 @@ class ShopgatePaymentHelperPaypalPlus extends ShopgatePaymentHelper
     {
         $paymentInfos = $this->shopgateOrder->getPaymentInfos();
 
-        /** @var oxpsPayPalPlusPaymentData $data */
-        $data = oxNew('oxpsPayPalPlusPaymentData');
+        $oxPayPalPlusClass = class_exists('oxpsPayPalPlusPaymentData')
+            ? 'oxpsPayPalPlusPaymentData'
+            : 'paypPayPalPlusPaymentData';
+        /** @var oxpsPayPalPlusPaymentData|paypPayPalPlusPaymentData $data */
+        $data = oxNew($oxPayPalPlusClass);
 
         $data->setOrderId($this->oxOrder->getId());
         $data->setSaleId($paymentInfos['payment_transaction_id']);


### PR DESCRIPTION
# Pull Request Template

## Description

PayPalPlus order could not be imported due to using the wrong payment data class.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
